### PR TITLE
Make it more linked-list-like

### DIFF
--- a/include/linked-list.h
+++ b/include/linked-list.h
@@ -6,6 +6,7 @@
 
 typedef struct LinkedRoot LinkedRoot;
 typedef bool (*ObjectCompare)(void* object1, void* object2);
+typedef bool (*LinkedListForEachCallback)(void *object, void *context);
 
 
 // Create a new LinkedRoot object, upon which all other linked list operations
@@ -62,3 +63,6 @@ int16_t linked_list_find(LinkedRoot* root, void* object);
 // be found, returns -1.
 // Uses the specified ObjectCompare function to compare objects.
 int16_t linked_list_find_compare(LinkedRoot* root, void* object, ObjectCompare compare);
+
+// Iterates over the list. Stops iterating if the callback returns false.
+void linked_list_foreach(LinkedRoot* root, LinkedListForEachCallback callback, void* context);

--- a/src/c/linked-list.c
+++ b/src/c/linked-list.c
@@ -150,6 +150,16 @@ int16_t linked_list_find_compare(LinkedRoot* root, void* object, ObjectCompare c
   return -1;
 }
 
+void linked_list_foreach(LinkedRoot* root, LinkedListForEachCallback callback, void* context) {
+  LinkedList* list = root->head;
+  while (list != NULL) {
+    if (!callback(list->object, context)) {
+      return;
+    }
+    list = list->next;
+  }
+}
+
 
 // Create a new LinkedList with the specified object.
 static LinkedList* create_list_item(void* object) {

--- a/src/c/linked-list.c
+++ b/src/c/linked-list.c
@@ -113,6 +113,7 @@ void linked_list_remove(LinkedRoot* root, uint16_t index) {
     }
     list->prev->next = list->next;
   }
+  free(list);
 }
 
 void linked_list_clear(LinkedRoot* root) {


### PR DESCRIPTION
This linked list provides no mechanism to iterate over the linked list, which is a thing that linked lists are actually quite good at. Instead you must count the length, then iterate through it, which takes O(n^2) time and is not the ideal way to use a linked list.

This adds `linked_list_foreach`, which allows more direct iteration.

It also adds a call to `free` in `linked_list_remove`, because otherwise the nodes are never freed.
